### PR TITLE
Fix attachments

### DIFF
--- a/controller/main_controller.php
+++ b/controller/main_controller.php
@@ -773,7 +773,10 @@ class main_controller
 				{
 					foreach ($attachments as $attachment)
 					{
-						$this->template->assign_var('POST_ATTACHMENTS', $attachment);
+						$this->template->assign_block_vars('attachments', array(
+							'POST_ATTACHMENTS' => $attachment,
+							)
+						);
 					}
 				}
 			}

--- a/controller/main_controller.php
+++ b/controller/main_controller.php
@@ -734,18 +734,19 @@ class main_controller
 		$sort_url = $this->helper->route('threedi_hlposts_view', array('forum_id' => (int) $forum_id, 'post_id' => (int) $post_id)) . '?' . implode('&amp;', $params);
 
 		/* First let's render the text */
-		$text = $this->renderer->render($post['post_text']);
-
-		/**
-		 * Attachments - Include files needed for display attachments
-		 */
-		if (!function_exists('parse_attachments'))
-		{
-			include $this->root_path . 'includes/functions_content.' . $this->php_ext;
-		}
+		$censor = censor_text($post['post_text']);
+		$text = $this->renderer->render($censor);
 
 		if ($post['post_attachment'])
 		{
+			/**
+			 * Attachments - Include files needed for display attachments
+			 */
+			if (!function_exists('parse_attachments'))
+			{
+				include $this->root_path . 'includes/functions_content.' . $this->php_ext;
+			}
+
 			$sql = 'SELECT *
 				FROM ' . ATTACHMENTS_TABLE . '
 				WHERE post_msg_id = ' . (int) $post_id . '
@@ -761,10 +762,17 @@ class main_controller
 
 			if (count($attachments))
 			{
-				$update_count = array();
-
-				/* Only parses attachments placed inline? */
+				/* Only parses attachments placed inline */
 				parse_attachments((int) $post['forum_id'], $text, $attachments, $update_count);
+			}
+
+			/* Display the remaining of the attachments */
+			if (count($attachments))
+			{
+				foreach ($attachments as $attachment)
+				{
+					$this->template->assign_var('POST_ATTACHMENTS', $attachment);
+				}
 			}
 		}
 

--- a/styles/all/template/view_users_read.html
+++ b/styles/all/template/view_users_read.html
@@ -30,7 +30,15 @@
 
 				<div class="content highlight-post-overflow">
 					{{ POST_TEXT }}
-					{{ POST_ATTACHMENTS }}
+					<br>
+					<dl class="attachbox">
+						<dt>
+							{{ lang('ATTACHMENTS') }}
+						</dt>
+						{% for attachment in attachments %}
+							<dd>{{ attachment.POST_ATTACHMENTS }}<dd>
+						{% endfor %}
+					</dl>
 				</div>
 			</div>
 		</div>

--- a/styles/all/template/view_users_read.html
+++ b/styles/all/template/view_users_read.html
@@ -28,8 +28,9 @@
 					</div>
 				{% endif %}
 
-				<div class="content">
+				<div class="content highlight-post-overflow">
 					{{ POST_TEXT }}
+					{{ POST_ATTACHMENTS }}
 				</div>
 			</div>
 		</div>

--- a/styles/all/theme/hlposts.css
+++ b/styles/all/theme/hlposts.css
@@ -44,3 +44,9 @@
 	padding: 5px;
 	width: 100%;
 }
+
+.highlight-post-overflow {
+	overflow-y: scroll;
+	width: auto;
+	height: 350px;
+}


### PR DESCRIPTION
Till now only those placed inline were visible (parsed).
This fix displays all the remaining attachments of a post.

![post_data_attachs](https://user-images.githubusercontent.com/480857/48961897-e3194c00-ef78-11e8-8bd9-44e156407be8.png)


